### PR TITLE
Fix: Correct fr unit calculation in minmax() track sizing

### DIFF
--- a/grid-lanes-polyfill.js
+++ b/grid-lanes-polyfill.js
@@ -331,9 +331,7 @@
 
     for (const lane of lanes) {
       if (typeof lane.max === "object" && lane.max.fr) {
-        lane.size = Math.max(lane.min, frUnit * lane.max.fr);
-      } else if (typeof lane.max === "number") {
-        lane.size = Math.min(lane.max, Math.max(lane.min, lane.min));
+        lane.size = lane.min + (frUnit * lane.max.fr);
       } else {
         lane.size = lane.min;
       }


### PR DESCRIPTION
### Summary
Fixes the track sizing algorithm for `minmax(min, fr)` to properly distribute flexible space according to the CSS Grid specification.

### Problem
The polyfill was incorrectly calculating fr unit sizes using `Math.max(lane.min, frUnit * lane.max.fr)`, which replaced the minimum size instead of adding the flexible space to it. This caused columns with `minmax(16rem, 1fr)` to under-fill their container.

### Solution
Changed the calculation to `lane.min + (frUnit * lane.max.fr)`, which correctly implements the "base size + share of free space" behavior specified in CSS Grid.

### Changes
- Updated `calculateLaneSizes` function in `grid-lanes-polyfill.js`
- Simplified the track sizing logic by consolidating the else branches

### Testing
- Verified dev server correctly renders grid tracks
- Confirmed tracks now properly fill container width with flexible sizing

### Spec Compliance
This implementation now correctly follows the CSS Grid track sizing algorithm where fr units claim a fraction of available space (container width minus all minimums) and add it to the base size.

**Note on removed branch:** The `else if` for fixed number max values contained redundant math (`Math.max(lane.min, lane.min)`) that always evaluated to using `lane.min`. Since this polyfill doesn't measure content size during calculation, both the fixed-max and fallback cases should use the minimum size, so I consolidated them into a single `else` branch.